### PR TITLE
fix: fit the markmap to the container before export to aviod unnecessary padding

### DIFF
--- a/src/funcs.ts
+++ b/src/funcs.ts
@@ -116,6 +116,9 @@ export function addToolbar(mm) {
       } else {
         el.style.width = `${Math.ceil((g.width * rect.height) / g.height)}px`
       }
+
+      // after container resize, fit once manually
+      await mm.fit()
       const page = await logseq.Editor.getCurrentPage()
       if (el) {
         html2canvas(el, {}).then(async function (canvas: HTMLCanvasElement) {


### PR DESCRIPTION
close #43 

the result after we change:
![Oct-01-2022 15-57-00](https://user-images.githubusercontent.com/22862294/193399427-4b2a9db6-52d7-4a00-9592-cfad9165a5fd.gif)
